### PR TITLE
Make the image path configurable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           filesize: 20G
           memory: 6G
           host-cmd: |
-            wsl-bash -c "df -h"
+            ${{ matrix.name == 'Windows' && 'fsutil fsinfo drives' || 'df -h' }}
           debug: true
       - uses: ./
         id: test2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,5 @@ jobs:
         with:
           cmd: |
             echo "third test"
+          filesize: 30G
           image-path: ${{ steps.test2.outputs.image-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./
+        id: test1
         with:
           cmd: |
             sudo lsblk
@@ -27,3 +28,17 @@ jobs:
           host-cmd: |
             df -h
           debug: true
+      - uses: ./
+        id: test2
+        with:
+          cmd: |
+            echo "second test"
+          host-cmd: |
+            df -h
+          img-path: ${{ github.workspace }}/nixos.qcow2
+      - uses: ./
+        id: test3
+        with:
+          cmd: |
+            echo "second test"
+          img-path: ${{ steps.test2.outputs.image-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,22 +28,18 @@ jobs:
           filesize: 20G
           memory: 6G
           host-cmd: |
-            df -h
+            wsl-bash -c "df -h"
           debug: true
       - uses: ./
         id: test2
         with:
           cmd: |
             echo "Second test"
-          host-cmd: |
-            df -h
           image-path: /mnt/nixos.qcow2
       - uses: ./
         id: test3
         with:
           cmd: |
             echo "Third test"
-          host-cmd: |
-            df -h
           filesize: 30G
           image-path: ${{ steps.test2.outputs.image-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         id: test1
         with:
           cmd: |
+            systemd-analyze blame
             sudo lsblk
             sleep 5
             grep MemTotal /proc/meminfo
@@ -40,5 +41,5 @@ jobs:
         id: test3
         with:
           cmd: |
-            echo "second test"
+            echo "third test"
           image-path: ${{ steps.test2.outputs.image-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
             echo "second test"
           host-cmd: |
             df -h
-          image-path: ${{ github.workspace }}/nixos.qcow2
+          image-path: /mnt/nixos.qcow2
       - uses: ./
         id: test3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
             echo "second test"
           host-cmd: |
             df -h
-          img-path: ${{ github.workspace }}/nixos.qcow2
+          image-path: ${{ github.workspace }}/nixos.qcow2
       - uses: ./
         id: test3
         with:
           cmd: |
             echo "second test"
-          img-path: ${{ steps.test2.outputs.image-path }}
+          image-path: ${{ steps.test2.outputs.image-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
             sudo lsblk
             sleep 5
             grep MemTotal /proc/meminfo
+            echo "First test"
           filesize: 20G
           memory: 6G
           host-cmd: |
@@ -33,7 +34,7 @@ jobs:
         id: test2
         with:
           cmd: |
-            echo "second test"
+            echo "Second test"
           host-cmd: |
             df -h
           image-path: /mnt/nixos.qcow2
@@ -41,6 +42,8 @@ jobs:
         id: test3
         with:
           cmd: |
-            echo "third test"
+            echo "Third test"
+          host-cmd: |
+            df -h
           filesize: 30G
           image-path: ${{ steps.test2.outputs.image-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           filesize: 20G
           memory: 6G
           host-cmd: |
-            ${{ matrix.name == 'Windows' && 'fsutil fsinfo drives' || 'df -h' }}
+            df -h
           debug: true
       - uses: ./
         id: test2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           cmd: |
             echo "Second test"
-          image-path: /mnt/nixos.qcow2
+          image-path: ${{ matrix.name == 'Linux' && '/mnt/nixos.qcow2' || format('{0}/nixos.qcow2', github.workspace) }} 
       - uses: ./
         id: test3
         with:

--- a/action.yml
+++ b/action.yml
@@ -244,6 +244,6 @@ runs:
             try:
                 await run("shutdown now", print_error=True)
             except ExecInterruptedError:
-                await qmp.disconnect()
+                pass
         asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -233,7 +233,7 @@ runs:
                     except:
                         await asyncio.sleep(1)
                 return res
-            bash_path = r"${{ inputs.bash_path }}" or r"/run/current-system/sw/bin/bash"
+            bash_path = r"${{ inputs.bash-path }}" or r"/run/current-system/sw/bin/bash"
             await run_force("systemctl is-system-running --wait", print_error=True, bash_path=bash_path)
             await run(f'''mkdir -p "{os.environ['NIXOS_RUN_GSTDIR']}"''', print_error=True, bash_path=bash_path)
             await run(f'''mount -t 9p -o trans=virtio,version=9p2000.L mnt "{os.environ['NIXOS_RUN_GSTDIR']}"''', print_error=True, bash_path=bash_path)

--- a/action.yml
+++ b/action.yml
@@ -241,7 +241,7 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
-            await qmp.execute('guest-shutdown',{'mode':'powerdown'})
+            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'shutdown now']})
             await proc.wait()
         asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -234,6 +234,7 @@ runs:
             await run("mkdir -p /tmp/cmd", print_error=True)
             await run("mount -t 9p -o trans=virtio,version=9p2000.L cmd /tmp/cmd", print_error=True)
             await run("chmod 755 /tmp/cmd/cmd.sh", print_error=True)
+            await run("rm -f /tmp/cmd/log.txt", print_error=True)
             await run("touch /tmp/cmd/log.txt", print_error=True)
             log = await asyncio.create_subprocess_shell(f'''tail -f {os.environ['NIXOS_RUN_CMDDIR']}/log.txt''')
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:

--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
         import asyncio
         import socket
         import base64
-        from qemu.qmp import QMPClient, ExecInterruptedError
+        from qemu.qmp import QMPClient
         sys.stdout.reconfigure(encoding='utf-8')
         class CommandError(Exception):
             "Nonzero exit of guest-exec command"
@@ -241,9 +241,7 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
-            try:
-                await run("shutdown now", print_error=True)
-            except ExecInterruptedError:
-                pass
+            await qmp.execute('guest-shutdown',{'mode':'powerdown'})
+            await proc.wait()
         asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,8 @@ runs:
         7z e "$NIXOS_RUN_TMPDIR/nixos-qcow-nocloud.7z" -o"$NIXOS_RUN_TMPDIR/extraction"
         pattern="$NIXOS_RUN_TMPDIR/extraction/*"
         files=( $pattern )
-        mv "${files[0]}" "$NIXOS_RUN_IMGPATH"
+        sudo mv "${files[0]}" "$NIXOS_RUN_IMGPATH"
+        sudo chmod 777 "$NIXOS_RUN_IMGPATH"
       shell: wsl-bash {0}
       env:
         WSLENV: NIXOS_RUN_TMPDIR/p:NIXOS_RUN_IMGPATH/p

--- a/action.yml
+++ b/action.yml
@@ -240,8 +240,12 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
-            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'sleep 1 && shutdown now']})
+            #For a cleaner shutdown without QMP disconnection errors
+            await run("rm -f /tmp/cmd/shutdown", print_error=True)
+            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
             await qmp.disconnect()
+            with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/shutdown''', 'a'):  # Create file if does not exist
+               pass
             await proc.wait()
         asyncio.run(main(), debug=True)
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -240,7 +240,7 @@ runs:
             log = await asyncio.create_subprocess_shell(f'''tail -f {os.environ['NIXOS_RUN_CMDDIR']}/log.txt''')
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
-            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
+            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=True, sleep_interval=1)
             #For a cleaner shutdown without QMP disconnection errors
             await run("rm -f /tmp/cmd/shutdown", print_error=True)
             await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})

--- a/action.yml
+++ b/action.yml
@@ -242,7 +242,7 @@ runs:
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
             try:
                 await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'shutdown now']})
-            except:
+            except EOFError:
                 pass
             await proc.wait()
         asyncio.run(main())

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         sudo aria2c --dir="$NIXOS_RUN_TMPDIR" https://github.com/physics-enthusiast/nixos-image/releases/download/${{ steps.read_manifest.outputs.tag_name }}/nixos-qcow-nocloud.7z
       shell: wsl-bash {0}
       env:
-        WSLENV: GITHUB_OUTPUT/p:NIXOS_RUN_TMPDIR/p
+        WSLENV: NIXOS_RUN_TMPDIR/p
     - name: Save cache
       id: save-cache-image
       uses: actions/cache/save@v4
@@ -161,12 +161,15 @@ runs:
         pattern="$NIXOS_RUN_TMPDIR/extraction/*"
         files=( $pattern )
         mv "${files[0]}" "$NIXOS_RUN_IMGPATH"
+      shell: wsl-bash {0}
+      env:
+        WSLENV: NIXOS_RUN_TMPDIR/p:NIXOS_RUN_IMGPATH/p
     - name: Resize image
       run: |
         qemu-img resize "$NIXOS_RUN_IMGPATH" ${{ ( inputs.filesize != '' && inputs.filesize ) || '10G' }}
       shell: wsl-bash {0}
       env:
-        WSLENV: GITHUB_OUTPUT/p:NIXOS_RUN_TMPDIR/p:NIXOS_RUN_IMGPATH/p
+        WSLENV: NIXOS_RUN_IMGPATH/p
     - name: Start VM
       run: |
         import os

--- a/action.yml
+++ b/action.yml
@@ -242,5 +242,5 @@ runs:
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
             await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'sleep 1 && shutdown now']})
             await proc.wait()
-        asyncio.run(main())
+        asyncio.run(main(), debug=True)
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -217,6 +217,7 @@ runs:
                             print(output)
                     else:
                         output = None
+                    await asyncio.sleep(5) #Give error time to print
                     if not output and print_error:
                         raise CommandError("Command failed without error message") 
                     else:
@@ -240,7 +241,7 @@ runs:
             log = await asyncio.create_subprocess_shell(f'''tail -f {os.environ['NIXOS_RUN_CMDDIR']}/log.txt''')
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
-            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=True, sleep_interval=1)
+            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
             #For a cleaner shutdown without QMP disconnection errors
             await run("rm -f /tmp/cmd/shutdown", print_error=True)
             await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})

--- a/action.yml
+++ b/action.yml
@@ -161,6 +161,9 @@ runs:
         pattern="$NIXOS_RUN_TMPDIR/extraction/*"
         files=( $pattern )
         mv "${files[0]}" "$NIXOS_RUN_IMGPATH"
+    - name: Resize image
+      if: steps.get_paths.outputs.image-path-exists != 'True'
+      run: |
         qemu-img resize "$NIXOS_RUN_IMGPATH" ${{ ( inputs.filesize != '' && inputs.filesize ) || '10G' }}
       shell: wsl-bash {0}
       env:
@@ -192,7 +195,7 @@ runs:
                     await asyncio.sleep(1) 
             await qmp.connect(qga_sock)
             res = await qmp.execute('guest-ping')
-            async def run(cmd, print_output=False, print_error=False, sleep_interval=1, final_pause=5):
+            async def run(cmd, print_output=False, print_error=False, sleep_interval=1):
                 pid = await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
                 res = await qmp.execute('guest-exec-status',pid)
                 while not res['exited']:
@@ -205,7 +208,6 @@ runs:
                             print(output)
                     else:
                         output = None
-                    await asyncio.sleep(final_pause)
                     return output
                 else:
                     if 'err-data' in res:
@@ -214,15 +216,14 @@ runs:
                             print(output)
                     else:
                         output = None
-                    await asyncio.sleep(final_pause)
                     if not output and print_error:
                         raise CommandError("Command failed without error message") 
                     else:
                         raise CommandError("Command failed")
-            async def run_force(cmd, print_output=False, print_error=False, sleep_interval=1, final_pause=5):
+            async def run_force(cmd, print_output=False, print_error=False, sleep_interval=1):
                 while True:
                     try:
-                        res = await run(cmd, print_output=print_output, print_error=print_error, sleep_interval=sleep_interval, final_pause=final_pause)
+                        res = await run(cmd, print_output=print_output, print_error=print_error, sleep_interval=sleep_interval)
                         break
                     except:
                         await asyncio.sleep(1)
@@ -237,6 +238,7 @@ runs:
             log = await asyncio.create_subprocess_shell(f'''tail -f {os.environ['NIXOS_RUN_CMDDIR']}/log.txt''')
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
-            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1, final_pause=5)
+            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
+            await run("shutdown now", print_error=True)
         asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,6 @@ inputs:
   cmd:
     description: 'Command to run'
     required: false
-    default: ''
   filesize:
     description: 'Size of the image file'
     required: false
@@ -23,7 +22,6 @@ inputs:
   host-cmd:
     description: 'Optional command to run on the host at the same time the guest is started'
     required: false
-    default: ''
   debug:
     description: 'Log the full OS boot sequence, for testing'
     required: false
@@ -115,13 +113,13 @@ runs:
       uses: DamianReeves/write-file-action@master
       with:
         path: ${{ env.NIXOS_RUN_CMDDIR }}/host_cmd.txt
-        contents: ${{ inputs.host-cmd }}
+        contents: ${{ ( inputs.host-cmd != '' && inputs.host-cmd ) || ':' }}
         write-mode: overwrite
     - name: Prepare guest command
       uses: DamianReeves/write-file-action@master
       with:
         path: ${{ env.NIXOS_RUN_CMDDIR }}/cmd.sh
-        contents: ${{ inputs.cmd }}
+        contents: ${{ ( inputs.cmd != '' && inputs.cmd ) || ':' }}
         write-mode: overwrite
     - name: Fetch prebuilt NixOS image manifest
       id: read_manifest

--- a/action.yml
+++ b/action.yml
@@ -197,7 +197,7 @@ runs:
             await qmp.connect(qga_sock)
             res = await qmp.execute('guest-ping')
             async def run(cmd, print_output=False, print_error=False, sleep_interval=1):
-                pid = await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
+                pid = await qmp.execute('guest-exec',{'path':'bash','arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
                 res = await qmp.execute('guest-exec-status',pid)
                 while not res['exited']:
                     await asyncio.sleep(sleep_interval)

--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
         import asyncio
         import socket
         import base64
-        from qemu.qmp import QMPClient
+        from qemu.qmp import QMPClient, ExecInterruptedError
         sys.stdout.reconfigure(encoding='utf-8')
         class CommandError(Exception):
             "Nonzero exit of guest-exec command"
@@ -241,6 +241,9 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
-            await run("shutdown now", print_error=True)
+            try:
+                await run("shutdown now", print_error=True)
+            except ExecInterruptedError:
+                await qmp.disconnect()
         asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,6 @@ runs:
         files=( $pattern )
         mv "${files[0]}" "$NIXOS_RUN_IMGPATH"
     - name: Resize image
-      if: steps.get_paths.outputs.image-path-exists != 'True'
       run: |
         qemu-img resize "$NIXOS_RUN_IMGPATH" ${{ ( inputs.filesize != '' && inputs.filesize ) || '10G' }}
       shell: wsl-bash {0}

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   image-path:
     description: "Path of VM disk image file"
     required: false
+  bash-path:
+    description: "Path to bash binary on guest"
+    required: false
   host-cmd:
     description: 'Optional command to run on the host at the same time the guest is started'
     required: false
@@ -196,8 +199,8 @@ runs:
                     await asyncio.sleep(1) 
             await qmp.connect(qga_sock)
             res = await qmp.execute('guest-ping')
-            async def run(cmd, print_output=False, print_error=False, sleep_interval=1):
-                pid = await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
+            async def run(cmd, print_output=False, print_error=False, sleep_interval=1, bash_path='/run/current-system/sw/bin/bash'):
+                pid = await qmp.execute('guest-exec',{'path':bash_path,'arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
                 res = await qmp.execute('guest-exec-status',pid)
                 while not res['exited']:
                     await asyncio.sleep(sleep_interval)
@@ -222,29 +225,30 @@ runs:
                         raise CommandError("Command failed without error message") 
                     else:
                         raise CommandError("Command failed")
-            async def run_force(cmd, print_output=False, print_error=False, sleep_interval=1):
+            async def run_force(cmd, print_output=False, print_error=False, sleep_interval=1, bash_path='/run/current-system/sw/bin/bash'):
                 while True:
                     try:
-                        res = await run(cmd, print_output=print_output, print_error=print_error, sleep_interval=sleep_interval)
+                        res = await run(cmd, print_output=print_output, print_error=print_error, sleep_interval=sleep_interval, bash_path=bash_path)
                         break
                     except:
                         await asyncio.sleep(1)
                 return res
-            await run_force("systemctl is-system-running --wait", print_error=True)
-            await run(f'''mkdir -p "{os.environ['NIXOS_RUN_GSTDIR']}"''', print_error=True)
-            await run(f'''mount -t 9p -o trans=virtio,version=9p2000.L mnt "{os.environ['NIXOS_RUN_GSTDIR']}"''', print_error=True)
-            await run("mkdir -p /tmp/cmd", print_error=True)
-            await run("mount -t 9p -o trans=virtio,version=9p2000.L cmd /tmp/cmd", print_error=True)
-            await run("chmod 755 /tmp/cmd/cmd.sh", print_error=True)
-            await run("rm -f /tmp/cmd/log.txt", print_error=True)
-            await run("touch /tmp/cmd/log.txt", print_error=True)
+            bash_path = r"${{ inputs.bash_path }}" or r"/run/current-system/sw/bin/bash"
+            await run_force("systemctl is-system-running --wait", print_error=True, bash_path=bash_path)
+            await run(f'''mkdir -p "{os.environ['NIXOS_RUN_GSTDIR']}"''', print_error=True, bash_path=bash_path)
+            await run(f'''mount -t 9p -o trans=virtio,version=9p2000.L mnt "{os.environ['NIXOS_RUN_GSTDIR']}"''', print_error=True, bash_path=bash_path)
+            await run("mkdir -p /tmp/cmd", print_error=True, bash_path=bash_path)
+            await run("mount -t 9p -o trans=virtio,version=9p2000.L cmd /tmp/cmd", print_error=True, bash_path=bash_path)
+            await run("chmod 755 /tmp/cmd/cmd.sh", print_error=True, bash_path=bash_path)
+            await run("rm -f /tmp/cmd/log.txt", print_error=True, bash_path=bash_path)
+            await run("touch /tmp/cmd/log.txt", print_error=True, bash_path=bash_path)
             log = await asyncio.create_subprocess_shell(f'''tail -f {os.environ['NIXOS_RUN_CMDDIR']}/log.txt''')
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
-            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
+            await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1, bash_path=bash_path)
             #For a cleaner shutdown without QMP disconnection errors
-            await run("rm -f /tmp/cmd/shutdown", print_error=True)
-            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
+            await run("rm -f /tmp/cmd/shutdown", print_error=True, bash_path=bash_path)
+            await qmp.execute('guest-exec',{'path':bash_path,'arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
             await qmp.disconnect()
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/shutdown''', 'a'):  # Create file if does not exist
                pass

--- a/action.yml
+++ b/action.yml
@@ -240,7 +240,10 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
-            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'shutdown now']})
+            try:
+                await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'shutdown now']})
+            except:
+                pass
             await proc.wait()
         asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -248,5 +248,5 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/shutdown''', 'a'):  # Create file if does not exist
                pass
             await proc.wait()
-        asyncio.run(main(), debug=True)
+        asyncio.run(main())
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -78,16 +78,16 @@ runs:
       if: runner.os == 'Linux'
       run: |
         cd "$NIXOS_RUN_TMPDIR"
-        mkdir bash-redirect
-        ln -s $(which bash) bash-redirect/wsl-bash
+        mkdir -p bash-redirect
+        ln -sf $(which bash) bash-redirect/wsl-bash
         echo "$PWD/bash-redirect" >> "$GITHUB_PATH"
       shell: bash
     - name: Prepare common shell (Darwin)
       if: runner.os == 'macOS'
       run: |
         cd "$NIXOS_RUN_TMPDIR"
-        mkdir bash-redirect
-        ln -s $(which bash) bash-redirect/wsl-bash
+        mkdir -p bash-redirect
+        ln -sf $(which bash) bash-redirect/wsl-bash
         echo "$PWD/bash-redirect" >> "$GITHUB_PATH"
       shell: bash
     - name: Install dependencies (Windows)
@@ -156,7 +156,7 @@ runs:
     - name: Extract image
       if: steps.get_paths.outputs.image-path-exists != 'True'
       run: |
-        mkdir "$NIXOS_RUN_TMPDIR/extraction"
+        mkdir -p "$NIXOS_RUN_TMPDIR/extraction"
         7z e "$NIXOS_RUN_TMPDIR/nixos-qcow-nocloud.7z" -o"$NIXOS_RUN_TMPDIR/extraction"
         pattern="$NIXOS_RUN_TMPDIR/extraction/*"
         files=( $pattern )

--- a/action.yml
+++ b/action.yml
@@ -244,7 +244,7 @@ runs:
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
             #For a cleaner shutdown without QMP disconnection errors
             await run("rm -f /tmp/cmd/shutdown", print_error=True)
-            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
+            await qmp.execute('guest-exec',{'path':'bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
             await qmp.disconnect()
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/shutdown''', 'a'):  # Create file if does not exist
                pass

--- a/action.yml
+++ b/action.yml
@@ -241,6 +241,7 @@ runs:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
             await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'sleep 1 && shutdown now']})
+            await qmp.disconnect()
             await proc.wait()
         asyncio.run(main(), debug=True)
       shell: python

--- a/action.yml
+++ b/action.yml
@@ -197,7 +197,7 @@ runs:
             await qmp.connect(qga_sock)
             res = await qmp.execute('guest-ping')
             async def run(cmd, print_output=False, print_error=False, sleep_interval=1):
-                pid = await qmp.execute('guest-exec',{'path':'bash','arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
+                pid = await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', '{}'.format(cmd)],'capture-output':'separated'})
                 res = await qmp.execute('guest-exec-status',pid)
                 while not res['exited']:
                     await asyncio.sleep(sleep_interval)
@@ -244,7 +244,7 @@ runs:
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
             #For a cleaner shutdown without QMP disconnection errors
             await run("rm -f /tmp/cmd/shutdown", print_error=True)
-            await qmp.execute('guest-exec',{'path':'bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
+            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'while [ ! -f /tmp/cmd/shutdown ]; do sleep 1; done && shutdown now']})
             await qmp.disconnect()
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/shutdown''', 'a'):  # Create file if does not exist
                pass

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   guest-dir:
     description: 'Path of mounted directory in VM'
     required: false
+  image-path:
+    description: "Path of VM disk image file"
+    required: false
   host-cmd:
     description: 'Optional command to run on the host at the same time the guest is started'
     required: false
@@ -50,14 +53,17 @@ runs:
         relpath = r"${{ inputs.host-dir }}" or r"./"
         abspath = os.path.abspath(relpath)
         gstpath = r"${{ inputs.guest-dir }}" or r"/tmp/mnt"
-        imgpath = os.path.abspath(r"${{ runner.temp }}/nixos-run/nixos.qcow2")
+        imgpath = r"${{ inputs.image-path }}" or os.path.abspath(r"${{ runner.temp }}/nixos-run/nixos.qcow2")
+        imgpath_exists = os.path.isfile(imgpath)
         with open(os.environ['GITHUB_ENV'], 'a') as fh:
             print(f'NIXOS_RUN_TMPDIR={tmppath}', file=fh)
             print(f'NIXOS_RUN_CMDDIR={cmdpath}', file=fh)
             print(f'NIXOS_RUN_MNTDIR={abspath}', file=fh)
             print(f'NIXOS_RUN_GSTDIR={gstpath}', file=fh)
+            print(f'NIXOS_RUN_IMGPATH={imgpath}', file=fh)
         with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
             print(f'image-path={imgpath}', file=fh)
+            print(f'image-path-exists={imgpath_exists}', file=fh)
       shell: python
     - name: Prepare common shell (Windows)
       if: runner.os == 'Windows'
@@ -119,6 +125,7 @@ runs:
         write-mode: overwrite
     - name: Fetch prebuilt NixOS image manifest
       id: read_manifest
+      if: steps.get_paths.outputs.image-path-exists != 'True'
       uses: cardinalby/git-get-release-action@v1
       env:
         GITHUB_TOKEN: ${{ github.token }} 
@@ -127,12 +134,13 @@ runs:
         latest: 1
     - name: Restore cache
       id: restore-cache-image
+      if: steps.get_paths.outputs.image-path-exists != 'True'
       uses: actions/cache/restore@v4
       with:
         path: ${{ env.NIXOS_RUN_TMPDIR }}/nixos-qcow-nocloud.7z
         key: ${{ steps.read_manifest.outputs.published_at }}
     - name: Fetch prebuilt NixOS image
-      if: steps.restore-cache-image.outputs.cache-hit != 'true'
+      if: steps.restore-cache-image.outputs.cache-hit != 'true' && steps.get_paths.outputs.image-path-exists != 'True'
       run: |
         sudo aria2c --dir="$NIXOS_RUN_TMPDIR" https://github.com/physics-enthusiast/nixos-image/releases/download/${{ steps.read_manifest.outputs.tag_name }}/nixos-qcow-nocloud.7z
       shell: wsl-bash {0}
@@ -141,21 +149,22 @@ runs:
     - name: Save cache
       id: save-cache-image
       uses: actions/cache/save@v4
-      if: steps.restore-cache-image.outputs.cache-hit != 'true'
+      if: steps.restore-cache-image.outputs.cache-hit != 'true' && steps.get_paths.outputs.image-path-exists != 'True'
       with:
         path: ${{ env.NIXOS_RUN_TMPDIR }}/nixos-qcow-nocloud.7z
         key: ${{ steps.read_manifest.outputs.published_at }}
     - name: Extract image
+      if: steps.get_paths.outputs.image-path-exists != 'True'
       run: |
         mkdir "$NIXOS_RUN_TMPDIR/extraction"
         7z e "$NIXOS_RUN_TMPDIR/nixos-qcow-nocloud.7z" -o"$NIXOS_RUN_TMPDIR/extraction"
         pattern="$NIXOS_RUN_TMPDIR/extraction/*"
         files=( $pattern )
-        mv "${files[0]}" "$NIXOS_RUN_TMPDIR/nixos.qcow2"
-        qemu-img resize "$NIXOS_RUN_TMPDIR/nixos.qcow2" ${{ ( inputs.filesize != '' && inputs.filesize ) || '10G' }}
+        mv "${files[0]}" "$NIXOS_RUN_IMGPATH"
+        qemu-img resize "$NIXOS_RUN_IMGPATH" ${{ ( inputs.filesize != '' && inputs.filesize ) || '10G' }}
       shell: wsl-bash {0}
       env:
-        WSLENV: GITHUB_OUTPUT/p:NIXOS_RUN_TMPDIR/p
+        WSLENV: GITHUB_OUTPUT/p:NIXOS_RUN_TMPDIR/p:NIXOS_RUN_IMGPATH/p
     - name: Start VM
       run: |
         import os
@@ -168,7 +177,7 @@ runs:
         class CommandError(Exception):
             "Nonzero exit of guest-exec command"
             pass
-        cmd = f'''qemu-system-x86_64 -nographic -m ${{ ( inputs.memory != '' && inputs.memory ) || '4G' }} -chardev socket,id=qga0,host=localhost,port=9876,server=on -device virtio-serial -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 -fsdev local,security_model=mapped,id=fsdev0,path="{os.environ['NIXOS_RUN_CMDDIR']}" -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=cmd -fsdev local,security_model=mapped,id=fsdev1,path="{os.environ['NIXOS_RUN_MNTDIR']}" -device virtio-9p-pci,id=fs1,fsdev=fsdev1,mount_tag=mnt -smp {os.cpu_count()} -nic user -hda "{os.environ['NIXOS_RUN_TMPDIR']}/nixos.qcow2" -accel "whpx" -accel "kvm" -accel "hvf" -accel "tcg"'''
+        cmd = f'''qemu-system-x86_64 -nographic -m ${{ ( inputs.memory != '' && inputs.memory ) || '4G' }} -chardev socket,id=qga0,host=localhost,port=9876,server=on -device virtio-serial -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 -fsdev local,security_model=mapped,id=fsdev0,path="{os.environ['NIXOS_RUN_CMDDIR']}" -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=cmd -fsdev local,security_model=mapped,id=fsdev1,path="{os.environ['NIXOS_RUN_MNTDIR']}" -device virtio-9p-pci,id=fs1,fsdev=fsdev1,mount_tag=mnt -smp {os.cpu_count()} -nic user -hda "{os.environ['NIXOS_RUN_IMGPATH']}" -accel "whpx" -accel "kvm" -accel "hvf" -accel "tcg"'''
         async def main():
             proc = await asyncio.create_subprocess_shell(cmd${{ ( inputs.debug != 'true' && ', stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL' ) || '' }})
             qmp = QMPClient()

--- a/action.yml
+++ b/action.yml
@@ -240,10 +240,7 @@ runs:
             with open(f'''{os.environ['NIXOS_RUN_CMDDIR']}/host_cmd.txt''') as f:
                 coproc = await asyncio.create_subprocess_shell(f.read())
             await run("stdbuf -oL -eL /tmp/cmd/cmd.sh &> /tmp/cmd/log.txt", print_output=False, print_error=False, sleep_interval=1)
-            try:
-                await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'shutdown now']})
-            except EOFError:
-                pass
+            await qmp.execute('guest-exec',{'path':'/run/current-system/sw/bin/bash','arg':['-lc', 'sleep 1 && shutdown now']})
             await proc.wait()
         asyncio.run(main())
       shell: python


### PR DESCRIPTION
Enables the action to be run multiple times. If the image specified by 'image-path' already exists (from a previous run of the action or otherwise), it will be used as is rather than creating a new one. If the image was not created by a previous invocation, it must have QEMU guest-agent, virtio-9p support, bash (at `/run/current-system/sw/bin/bash` or else specified by the `bash-path` input), and a systemctl (> v240) binary accessible on its PATH. 